### PR TITLE
Remove allowbackup from library project

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.dgreenhalgh.android.simpleitemdecorationsample" >
+<manifest package="com.dgreenhalgh.android.simpleitemdecorationsample"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
-        <activity android:name=".controller.MainActivity" >
+        android:theme="@style/AppTheme">
+        <activity android:name=".controller.MainActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name=".controller.VerticalLinearLayoutManagerSampleActivity" />
-        <activity android:name=".controller.HorizontalLinearLayoutManagerSampleActivity" />
-        <activity android:name=".controller.GridLayoutManagerSampleActivity" />
+        <activity android:name=".controller.VerticalLinearLayoutManagerSampleActivity"/>
+        <activity android:name=".controller.HorizontalLinearLayoutManagerSampleActivity"/>
+        <activity android:name=".controller.GridLayoutManagerSampleActivity"/>
     </application>
 
 </manifest>

--- a/simpleitemdecoration/src/main/AndroidManifest.xml
+++ b/simpleitemdecoration/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.dgreenhalgh.android.simpleitemdecoration">
+<manifest package="com.dgreenhalgh.android.simpleitemdecoration"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application android:label="@string/app_name"/>
 
 </manifest>


### PR DESCRIPTION
If you add `android:allowBackup="false"` to your project you get the following error:

```
Error:Execution failed for task ':app:processDevelopmentProjectDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:19:9-36
  	is also present at [com.bignerdranch.android:simple-item-decoration:1.0.0] AndroidManifest.xml:12:9-35 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:17:5-90:19 to override.
```

The cause of the problem is library project setting the allowBackup tag, the error message suggest to add `tools:replace="android:allowBackup"` on library project, however as the project does not need to declare this tag I just remove it. I also set the allowback to false in the sample to reproduce the problem.